### PR TITLE
Config file path parsing optimization

### DIFF
--- a/LiteRadar/__init__.py
+++ b/LiteRadar/__init__.py
@@ -21,8 +21,6 @@
 #   Ideas about this tool is written as a publisher, you could view the [PDF]
 #   (http://dl.acm.org/citation.cfm?id=2889178) here.
 
-from libradar import LibRadar
-
 __all__ = (
     "__title__", "__summary__", "__uri__", "__version__", "__author__",
     "__email__", "__license__", "__copyright__",

--- a/LiteRadar/_settings.py
+++ b/LiteRadar/_settings.py
@@ -20,9 +20,8 @@
 #   All the scripts in LibRadar need import this file.
 
 
-
-import os
 import logging.config
+import os
 
 """
     whether clean the workspace after work
@@ -48,7 +47,6 @@ DB_FEATURE_WEIGHT = 'feature_weight'
 DB_UN_OB_PN = 'un_ob_pn'
 DB_UN_OB_CNT = 'un_ob_cnt'
 
-
 """
     running_processes
 
@@ -59,7 +57,6 @@ DB_UN_OB_CNT = 'un_ob_cnt'
 # RUNNING_PROCESS_NUMBER = 8
 RUNNING_PROCESS_NUMBER = 1
 QUEUE_TIME_OUT = 30
-
 
 """
 IGNORE ZERO API FILES
@@ -74,11 +71,11 @@ Config Files
 """
 
 SCRIPT_PATH = os.path.split(os.path.realpath(__file__))[0]
-if not os.path.exists(SCRIPT_PATH + '/Data'):
-    os.mkdir(SCRIPT_PATH + '/Data')
-FILE_LOGGING = SCRIPT_PATH + '/Data/logging.conf'
-FILE_RULE = SCRIPT_PATH + '/Data/tag_rules.csv'
-LITE_DATASET_10 = SCRIPT_PATH + '/Data/lite_dataset_10.csv'
+if not os.path.exists(os.path.join(SCRIPT_PATH, 'Data')):
+    os.mkdir(os.path.join(SCRIPT_PATH, 'Data'))
+FILE_LOGGING = os.path.join(SCRIPT_PATH, 'Data', 'logging.conf')
+FILE_RULE = os.path.join(SCRIPT_PATH, 'Data', 'tag_rules.csv')
+LITE_DATASET_10 = os.path.join(SCRIPT_PATH, 'Data', 'lite_dataset_10.csv')
 
 """
     Logs

--- a/LiteRadar/literadar.py
+++ b/LiteRadar/literadar.py
@@ -33,6 +33,7 @@ class LibRadarLite(object):
     """
     LibRadar
     """
+
     def __init__(self, apk_path):
         """
         Init LibRadar instance with apk_path as a basestring.
@@ -55,7 +56,7 @@ class LibRadarLite(object):
             I think it should be replaced by a hash table as the API list could not be modified during the progress.
         """
         self.k_api_v_permission = dict()
-        with open(SCRIPT_PATH + "/Data/strict_api.csv", 'r') as api_and_permission:
+        with open(os.path.join(SCRIPT_PATH, 'Data', 'strict_api.csv'), 'r') as api_and_permission:
             for line in api_and_permission:
                 api, permission_with_colon = line.split(",")
                 permissions = permission_with_colon[:-2].split(":")
@@ -102,10 +103,10 @@ class LibRadarLite(object):
             # will contain a single element.
             basename = "classes%d.dex"
 
-            ## Little hack to let Python2 work without much trouble
+            # Little hack to let Python2 work without much trouble
             try:
                 x_range = xrange(2, sys.maxint)
-            except:
+            except Exception:
                 x_range = range(2, sys.maxsize)
 
             for i in x_range:


### PR DESCRIPTION
Hi,

I'm using this tool under Windows and I found the way you concatenate the path for those config files is not very ideal, therefore I  modify them using `os.path.join` for better compatibility. The code should work fine on both Windows and Linux now.

The invalid import in `__init__.py` was also removed since it is no longer used and might cause exceptions.

Thanks for rebuilding LibRadar using python 3.

Regards, 
Edwin 