### PR TITLE
Update literadar.py warning row 209

### DIFF
--- a/LiteRadar/literadar.py
+++ b/LiteRadar/literadar.py
@@ -206,7 +206,7 @@ class LibRadarLite(object):
                     such as '\x01Lcom/vungle/publisher/inject'
                 don't know exactly but could use code below to deal with it.
                 """
-                if class_name[0] is not 'L':
+                if class_name[0] != 'L':
                     l_index = class_name.find('L')
 
                     if l_index == '-1':


### PR DESCRIPTION
I saw this warning while running literadar.py:

```
literadar.py:209: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if class_name[0] is not 'L':
```

I changed "is not" to "!=".